### PR TITLE
opam: add some lower-bounds

### DIFF
--- a/opam
+++ b/opam
@@ -22,8 +22,8 @@ remove: [["ocamlfind" "remove" "launchd"]]
 
 depends: [
   "result"
-  "lwt"
-  "cstruct"
+  "lwt" {>= "2.4.3"}
+  "cstruct" {>= "0.7.0"}
   "ocamlfind" {build}
   "oasis" {build}
 ]


### PR DESCRIPTION
We need a `cstruct` with a depopt on lwt. We need a newish `lwt`, so I
went for the Mirage minimum version of 2.4.3.

Signed-off-by: David Scott dave.scott@unikernel.com
