### PR TITLE
Fix: inconsistent use of caml_strdup

### DIFF
--- a/lib/launchd_stubs.c
+++ b/lib/launchd_stubs.c
@@ -41,7 +41,7 @@ CAMLprim value stub_launch_activate_socket(value name) {
   err = launch_activate_socket(c_name, &listening_fds, &n_listening_fds);
   caml_acquire_runtime_system();
 
-  free((void*)c_name);
+  caml_stat_free((void*)c_name);
 
   switch (err) {
     case 0:


### PR DESCRIPTION
Hello. I'm doing a large-scale study of C stub sources on OPAM.

Your library makes use of the undocumented `caml_strdup` function, which currently returns a block that can be passed to `free` from the C standard library. In future, the implementation of this function [may change](https://github.com/ocaml/ocaml/pull/71), making it incompatible with `free` and breaking the code that abused the old undocumented semantics.

Regardless of whether the change of semantics will happen or not, being consistent about such matters should be considered good style.
