### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/launchd.opam
+++ b/launchd.opam
@@ -12,7 +12,7 @@ build: [
 ]
 
 depends: [
-  "dune"       {build}
+  "dune"
   "lwt"        {>= "2.4.3"}
   "cstruct"    {>= "1.0.0"}
   "cstruct-lwt"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.